### PR TITLE
Remove unnecessary comment in pull config.

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -2,7 +2,7 @@ version: "1"
 rules:
   - base: main
     upstream: opendatahub-io:main
-    mergeMethod: none # don't automatically merge
+    mergeMethod: none
     mergeUnstable: false
 label: "do-not-merge/hold"
 conflictLabel: "needs-rebase"


### PR DESCRIPTION
This should resolve: https://github.com/red-hat-data-services/data-science-pipelines-operator/actions/runs/4135425586 

since we only have the `pull.yml` in only downstream repo, that's why it occurred here and not upstream. Not sure why it did'nt identify the file name though.