### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-data-science-pipelines-operator-controller-v2-19

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -30,7 +30,8 @@ FROM registry.redhat.io/ubi8/ubi-minimal@sha256:43dde01be4e94afd22d8d95ee8abcc9f
 ARG USER=65532
 
 LABEL com.redhat.component="odh-data-science-pipelines-operator-controller-container" \
-      name="managed-open-data-hub/odh-data-science-pipelines-operator-controller-rhel8" \
+      name="rhoai/odh-data-science-pipelines-operator-controller-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.19::el8" \
       description="Manages lifecycle of Data Science Pipelines Custom Resources and associated Kubernetes resources" \
       summary="odh-data-science-pipelines-operator-controller" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
