### PR TITLE
bump go toolset

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,7 +1,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 as builder
 
 ARG SOURCE_CODE
 ARG TARGETOS


### PR DESCRIPTION
Bump go toolset to 1.25 to address [konflux failure](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-4/pipelineruns/odh-data-science-pipelines-operator-controller-v3-4-on-pusfkhtn) 
error logs: go: `go.mod requires go >= 1.25.7 (running go 1.24.6; GOTOOLCHAIN=local`
