### PR TITLE
ci: noop comments on PR #940 paths (control run)

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,3 +1,4 @@
+# No-op (branch ci/noop-touch-pr940-files): YAML comment only — workflow logic unchanged (control PR vs PR #940).
 name: Pre-commit
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # Build the manager binary
+# No-op (branch ci/noop-touch-pr940-files): comment-only; same file as CVE PR — builder image unchanged.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,5 @@
 # Build arguments
+# No-op (branch ci/noop-touch-pr940-files): comment-only; digest-pinned builder unchanged.
 ARG SOURCE_CODE=.
 
 FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/opendatahub-io/data-science-pipelines-operator
 
+// No-op (branch ci/noop-touch-pr940-files): comment-only change to match PR #940 paths; no Go/toolchain bump.
+
 go 1.21
 
 require (


### PR DESCRIPTION
Touch the same files as the CVE PR with comments only — no Go bump, no builder digest change, no workflow logic change. Used to compare CI failures (e.g. dspo-tests) against the security branch.

## The issue resolved by this Pull Request:
Resolves #<issue_number>

## Description of your changes:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

## Testing instructions
<!--- Add any information that testers/qe should be aware of when testing this PR. Examples include what components
to focus on, or what features are likely to be affected. -->

## Checklist
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
