### PR TITLE
chore: Update Konflux Dockerfile to use Go toolset 1.26.3 and native Go FIPS 140 configuration

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,7 +1,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:16e8f98fb6f83ee327388d5603892b0021562e65c399ed75d344d3d70b81fd26 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.3@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 as builder
 
 ARG SOURCE_CODE
 ARG TARGETOS
@@ -14,7 +14,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN GOTOOLCHAIN=local go mod download
 
 # Copy the go source
 COPY main.go main.go
@@ -24,7 +24,7 @@ COPY config/internal config/internal
 
 USER root
 # Build
-RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GO111MODULE=on GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -a -o manager main.go
+RUN GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GOFIPS140=v1.0.0 go build -tags no_openssl -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:850143255ee0d1915f09aaa09f6ed31f24086ba605c323badfbefa95b8c52b0e AS runtime
 


### PR DESCRIPTION
## Summary
- Bump go-toolset from 1.25 to 1.26.3 with pinned digest in Konflux Dockerfile
- Migrate FIPS from `GOEXPERIMENT=strictfipsruntime` to native `GOFIPS140=v1.0.0` with `-tags no_openssl`
- Switch from `CGO_ENABLED=1` to `CGO_ENABLED=0` (no CGO dependency in DSPO)
- Add `GOTOOLCHAIN=local` to `go mod download` and build

Syncs `Dockerfile.konflux` with the regular `Dockerfile` which was already updated via the ODH stable merge.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-70601