### PR TITLE
chore: bump go toolsets

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,7 +1,7 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:16e8f98fb6f83ee327388d5603892b0021562e65c399ed75d344d3d70b81fd26 as builder
 
 ARG SOURCE_CODE
 ARG TARGETOS


### PR DESCRIPTION
bumping go toolset to address build failure on 3.5 with logs attached:

```
go: go.mod requires go >= 1.26 (running go 1.25.9; GOTOOLCHAIN=local)
Error: building at STEP "RUN . /cachi2/cachi2.env &&     go mod download":
```

Will sync to 3.5 from main