### PR TITLE
fix: restore FIPS build flags in Dockerfile.konflux

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -25,7 +25,7 @@ COPY config/internal config/internal
 
 USER root
 # Build
-RUN GOTOOLCHAIN=local CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager .
+RUN GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GOFIPS140=v1.0.0 go build -tags no_openssl -a -o manager .
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:c5478a52c410e71c53839923c83a1480199a1e74ce5736fe3e3a5578dc399102 AS runtime
 


### PR DESCRIPTION
## Summary

- Restore `CGO_ENABLED=0`, `GOFIPS140=v1.0.0`, and `-tags no_openssl` in `Dockerfile.konflux` build line
- Aligns Konflux Dockerfile with the non-Konflux `Dockerfile` which already has the correct flags

## Root cause

PR #1064 fixed the missing `tls_profile.go` build error (adding `COPY tls_profile.go` and changing `main.go` → `.`) but accidentally reverted the FIPS build configuration from PR #1039.

The `go.mod` has `godebug fips140=on` (native Go FIPS), which conflicts with `GOLANG_FIPS=1` injected by the UBI9 base image. Without `-tags no_openssl` and `CGO_ENABLED=0`, both FIPS modes activate simultaneously, causing a runtime panic:

```
panic: opensslcrypto: GOLANG_FIPS and GODEBUG=fips140 are mutually exclusive
```

The build succeeds but the operator pod CrashLoopBackOff at startup.

## Change

```diff
- RUN GOTOOLCHAIN=local CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager .
+ RUN GOTOOLCHAIN=local CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GOFIPS140=v1.0.0 go build -tags no_openssl -a -o manager .
```

## Test plan

- [ ] Konflux build passes on all three architectures (x86_64, aarch64, ppc64le)
- [ ] Operator pod starts without FIPS panic
- [ ] Verify FIPS crypto is active: `go tool buildinfo manager | grep fips`

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-76057
Slack: https://redhat-internal.slack.com/archives/C0BCFE4JH27/p1783942941480499